### PR TITLE
fix: Allow layout updates on content changes

### DIFF
--- a/src/Expandable.tsx
+++ b/src/Expandable.tsx
@@ -48,7 +48,7 @@ const Expandable = ({
   const measureContent = () => {
     'worklet';
     const measured = measure(contentRef);
-    if (measured && measured.height > 0) {
+    if (measured && measured.height > 0 && measured.height !== measuredHeight.value) {
       setMeasuredHeight(measuredHeight, measured.height);
     }
   };
@@ -88,9 +88,7 @@ const Expandable = ({
       <Animated.View
         ref={contentRef}
         onLayout={() => {
-          if (measuredHeight.value === 0) {
-            scheduleOnUI(measureContent);
-          }
+          scheduleOnUI(measureContent);
         }}
         style={{ position: 'absolute', width: '100%' }}
       >


### PR DESCRIPTION
In the latest release I accidentally broke something important from this package, if it was expanded and content changes it won't stretch showing the new content 

# Before
https://github.com/user-attachments/assets/2e6b33fd-6c66-4e57-967c-9dc0a029aeba

# After 
https://github.com/user-attachments/assets/e0d64fa5-a8fc-4252-ae6e-56ac5e5a5b70
